### PR TITLE
Fixed bugged crossbow saving

### DIFF
--- a/plugin/src/main/java/com/goncalomb/bukkit/nbteditor/commands/inventories/InventoryForItems.java
+++ b/plugin/src/main/java/com/goncalomb/bukkit/nbteditor/commands/inventories/InventoryForItems.java
@@ -1,5 +1,7 @@
 package com.goncalomb.bukkit.nbteditor.commands.inventories;
 
+import com.goncalomb.bukkit.mylib.reflect.NBTTagCompound;
+import com.goncalomb.bukkit.mylib.reflect.NBTUtils;
 import org.bukkit.Material;
 import org.bukkit.entity.Player;
 import org.bukkit.event.inventory.InventoryCloseEvent;
@@ -7,6 +9,8 @@ import org.bukkit.inventory.ItemStack;
 
 import com.goncalomb.bukkit.nbteditor.nbt.BaseNBT;
 import com.goncalomb.bukkit.nbteditor.nbt.variables.ItemsVariable;
+
+import java.util.Arrays;
 
 public class InventoryForItems extends InventoryForSpecialVariable<ItemsVariable> {
 
@@ -28,6 +32,21 @@ public class InventoryForItems extends InventoryForSpecialVariable<ItemsVariable
 
 	@Override
 	protected void inventoryClose(InventoryCloseEvent event) {
+		if(Arrays.stream(getContents()).anyMatch(s -> s.getType() != null && s.getType() == Material.CROSSBOW)) {
+			//Concurrent Modification Exception workaround
+			ItemStack[] items = getContents().clone();
+			for (int i = 0; i < items.length; i++) {
+				ItemStack item = items[i];
+				if (item != null && item.getType() != null && item.getType() == Material.CROSSBOW) {
+					NBTTagCompound tags = NBTUtils.getItemStackTag(item);
+					if(tags.hasKey("ChargedProjectiles")) {
+						tags.remove("ChargedProjectiles");
+						NBTUtils.setItemStackTag(item, tags);
+						setItem(i, item);
+					}
+				}
+			}
+		}
 		_variable.setItems(getContents());
 		super.inventoryClose(event);
 	}


### PR DESCRIPTION
Before saving a crossbow item the mob is holding, remove the tag that can cause mobs to thanos snap themselves when spawning from spawners.