### PR TITLE
Book of Souls placement message + villager limit, update gradle version

### DIFF
--- a/build.gradle.kts
+++ b/build.gradle.kts
@@ -1,7 +1,7 @@
 import net.minecrell.pluginyml.bukkit.BukkitPluginDescription
 
 plugins {
-    id("com.playmonumenta.gradle-config") version "1.+"
+    id("com.playmonumenta.gradle-config") version "2.1+"
 }
 
 val commons = libs.commons

--- a/plugin/src/main/java/com/goncalomb/bukkit/nbteditor/bos/BookOfSoulsCI.java
+++ b/plugin/src/main/java/com/goncalomb/bukkit/nbteditor/bos/BookOfSoulsCI.java
@@ -89,7 +89,7 @@ final class BookOfSoulsCI extends CustomItem {
 				player.sendMessage("§cAttempted to spawn VILLAGER entity from too far away! Get within 6 blocks.");
 			} else {
 				String entityName = entityNBT.getData().getString("CustomName");
-				player.sendMessage("§aSpawned entity %1$s §a(%2$s) at coordinates %3$s, %4$s, %5$s.".formatted((entityName == null) ? entityNBT.getEntityType().name().toLowerCase() : entityName, entityNBT.getEntityType().name(), location.getBlockX(), location.getBlockY(), location.getBlockZ()));
+				player.sendMessage("§aSpawned entity %1$s §a(%2$s) at coordinates %3$s, %4$s, %5$s.".formatted((entityName == null) ? entityNBT.getEntityType().name() : entityName, entityNBT.getEntityType().name(), location.getBlockX(), location.getBlockY(), location.getBlockZ()));
 				entityNBT.spawn(location);
 			}
 			event.setCancelled(true);

--- a/plugin/src/main/java/com/goncalomb/bukkit/nbteditor/bos/BookOfSoulsCI.java
+++ b/plugin/src/main/java/com/goncalomb/bukkit/nbteditor/bos/BookOfSoulsCI.java
@@ -19,10 +19,12 @@
 
 package com.goncalomb.bukkit.nbteditor.bos;
 
+import com.goncalomb.bukkit.nbteditor.nbt.EntityNBT;
 import org.bukkit.ChatColor;
 import org.bukkit.Location;
 import org.bukkit.Material;
 import org.bukkit.block.Block;
+import org.bukkit.entity.EntityType;
 import org.bukkit.entity.Player;
 import org.bukkit.event.block.Action;
 import org.bukkit.event.block.BlockDispenseEvent;
@@ -82,7 +84,14 @@ final class BookOfSoulsCI extends CustomItem {
 		}
 
 		if (location != null) {
-			bos.getEntityNBT().spawn(location);
+			EntityNBT entityNBT = bos.getEntityNBT();
+			if (entityNBT.getEntityType() == EntityType.VILLAGER && event.getPlayer().getLocation().distance(location) >= 6) {
+				player.sendMessage("§cAttempted to spawn VILLAGER entity from too far away! Get within 6 blocks.");
+			} else {
+				String entityName = entityNBT.getData().getString("CustomName");
+				player.sendMessage("§aSpawned entity %1$s §a(%2$s) at coordinates %3$s, %4$s, %5$s.".formatted((entityName == null) ? entityNBT.getEntityType().name().toLowerCase() : entityName, entityNBT.getEntityType().name(), location.getBlockX(), location.getBlockY(), location.getBlockZ()));
+				entityNBT.spawn(location);
+			}
 			event.setCancelled(true);
 		} else {
 			player.sendMessage("§cNo block in sight!");


### PR DESCRIPTION
- Adds message sent to players when they place a Book of Souls, to prevent accidents. Includes BoS-defined CustomName, as well as the Entity's type. Includes coordinates.
- Adds distance limiter for Villager entity types to require the player to be 6 blocks or less away from where they want to place it. Once again, done to prevent accidents with outdated villagers.
- Update gradle version to 2.1+ so building locally and deploying actually works correctly